### PR TITLE
Made it work for portable and some other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,4 @@ This tool was made by Microsoft with :heart: for npm and Node, but it is provide
 implied. For details, please consult the `LICENSE` file.
 
 ## Contributing
-Contributions are extremely welcome! For JavScript code, please run `grunt test` to check your code against JSCS and JSHint. There's no formal coding guideline for the PowerShell pieces of this tool, but do write code that is commented and comprehensible.
+Contributions are extremely welcome! For JavaScript code, please run `grunt test` to check your code against JSCS and JSHint. There's no formal coding guideline for the PowerShell pieces of this tool, but do write code that is commented and comprehensible.

--- a/bin/npm-windows-upgrade
+++ b/bin/npm-windows-upgrade
@@ -11,10 +11,18 @@ var spawn = require('child_process').spawn,
     args = process.argv;
 
 // Helper functions
-function runPowershell(version, cb) {
+function runPowershell(version, nodePath, cb) {
     var scriptPath = path.resolve(__dirname, '../powershell/upgrade-npm.ps1'),
-        child = spawn('powershell.exe', ['-NoProfile', '-NoLogo', '& {& \'' + scriptPath + '\' -version \'' + version + '\'}']),
+        specialArgs = nodePath === null ?
+            '& {& \'' + scriptPath + '\' -version \'' + version + '\' }' :
+            '& {& \'' + scriptPath + '\' -version \'' + version + '\' -NodePath \'' + nodePath + '\' }',
+        psArgs = ['-NoProfile', '-NoLogo', specialArgs],
+        child = spawn('powershell.exe', psArgs),
         output = [];
+
+    if (nodePath) {
+        console.log('powershell executed with args: ' + psArgs.join(' '));
+    }
 
     child.stdout.on('data', function (data) {
         output.push(data.toString());
@@ -35,7 +43,7 @@ function runPowershell(version, cb) {
 function getAvailableVersions(cb) {
     exec('npm view npm versions --json', function (err, stdout) {
         if (err) {
-            return console.error(chalk.red.bold('We could not show latest available versions. Try running this script again with the version you want to install (npm-upgrade-windows --version:3.0.0'));
+            return console.error(chalk.red.bold('We could not show latest available versions. Try running this script again with the version you want to install (npm-windows-upgrade --version:3.0.0'));
         }
 
         cb(JSON.parse(stdout));
@@ -52,22 +60,36 @@ function checkForInternet(cb) {
     });
 }
 
+function getNodePath(cb) {
+    exec('npm config --global get prefix', function (err, stdout) {
+        if (err) {
+            console.log('Could not determine nodejs install location, will default to a program files directory.');
+            cb(null);
+        } else {
+            var nodePath = stdout.replace(/\n/, '');
+            cb(nodePath);
+        }
+    });
+}
+
 function upgradeNPM(version) {
     var spinner = new Spinner('Upgrading.. %s');
     spinner.start();
 
-    runPowershell(version, function (output) {
-        spinner.stop(false);
-        console.log('\n');
+    getNodePath(function (nodePath) {
+        runPowershell(version, nodePath, function (output) {
+            spinner.stop(false);
+            console.log('\n');
 
-        if (output[0] && output[0].indexOf('You must be administrator to run this script') > -1) {
-            console.log(chalk.bold.red('Upgrade aborted: You must be administrator to run this script. Upgrade aborted.'));
-        } else if (output && output.length > 0 && output[output.length - 1].indexOf('All done!') > -1) {
-            console.log(chalk.bold.green('Upgrade finished. Have a nice day!'));
-        } else {
-            console.log(chalk.bold.red('Error: We cannot confirm that the upgrade succeeded. The output of the script was: '));
-            console.log(output);
-        }
+            if (output[0] && output[0].indexOf('You must be administrator to run this script') > -1) {
+                console.log(chalk.bold.red('Upgrade aborted: You must be administrator to run this script. Upgrade aborted.'));
+            } else if (output && output.length > 0 && output[output.length - 1].indexOf('All done!') > -1) {
+                console.log(chalk.bold.green('Upgrade finished. Have a nice day!'));
+            } else {
+                console.log(chalk.bold.red('An unknown error occurred. The output of the upgrader script was: '));
+                console.log(output);
+            }
+        });
     });
 }
 
@@ -109,10 +131,14 @@ if (!isWin) {
 }
 
 // Print version
-console.log(chalk.yellow.bold('npm-upgrade-windows ' + package.version));
+console.log(chalk.yellow.bold('npm-windows-upgrade ' + package.version));
 
 // Execute
-inquirer.prompt({type: 'confirm', name: 'c', message: 'This tool will upgrade npm. Do you want to continue?'}, function (response) {
+inquirer.prompt({
+    type: 'confirm',
+    name: 'c',
+    message: 'This tool will upgrade npm. Do you want to continue?'
+}, function (response) {
     if (!response.c) {
         return console.log(chalk.bold.green('Well then, we\'re done here. Have a nice day!'));
     }

--- a/powershell/upgrade-npm.ps1
+++ b/powershell/upgrade-npm.ps1
@@ -5,7 +5,7 @@
 # felix.rieseberg@microsoft.com
 
 # ----------------------------------------------------------------------
-# Usage: ./upgrade-npm.ps1 
+# Usage: ./upgrade-npm.ps1
 # ----------------------------------------------------------------------
 [CmdletBinding()]
 Param(
@@ -50,15 +50,18 @@ if (!(IsAdministrator))
 #
 # Upgrade
 #
-$NodePath = $env:ProgramFiles + "\nodejs"
+$NodePath = npm config -g get prefix
 if ((Test-Path $NodePath) -ne $True) {
+  $NodePath = $env:ProgramFiles + "\nodejs"
+  if ((Test-Path $NodePath) -ne $True) {
     $NodePath = {env:ProgramFiles(x86)} + "\nodejs"
+  }
 }
 
 $NpmPath = $NodePath + "\node_modules\npm"
 "Assuming npm in " + $NpmPath
 
-if (Test-Path $NpmPath) 
+if (Test-Path $NpmPath)
 {
     # Create tmp directory, delete files if they exist
     $TempPath = $env:temp + "\npm_upgrade"
@@ -66,11 +69,11 @@ if (Test-Path $NpmPath)
     {
         New-Item -ItemType Directory -Force -Path $TempPath
     }
-    
+
     # Copy away .npmrc
     cd $NpmPath
     $Npmrc = $False
-    if (Test-Path .npmrc) 
+    if (Test-Path .npmrc)
     {
         $Npmrc = $True
         "Saving .npmrc"
@@ -81,9 +84,9 @@ if (Test-Path $NpmPath)
     cd $NodePath
     "Upgrading npm in " + $NodePath
     npm install npm@$version
-    
+
     # Copy .npmrc back
-    if ($Npmrc) 
+    if ($Npmrc)
     {
         "Restoring .npmrc"
         $TempFile = $TempPath + "\.npmrc"
@@ -91,7 +94,7 @@ if (Test-Path $NpmPath)
     }
 
     "All done!"
-} else 
+} else
 {
     "Could not find NPM in " + $env:ProgramFiles  + "\nodejs\node_modules\npm - aborting upgrade"
 }

--- a/powershell/upgrade-npm.ps1
+++ b/powershell/upgrade-npm.ps1
@@ -10,10 +10,13 @@
 [CmdletBinding()]
 Param(
     [Parameter(Mandatory=$True)]
-    [string]$version
+    [string]$version,
+    [string]$NodePath=(Join-Path $env:ProgramFiles nodejs)
 )
 
 $ErrorActionPreference = "Stop"
+
+Write-Debug "PowerShell received $NodePath as the nodejs path."
 
 #
 # Self-Elevate
@@ -50,12 +53,8 @@ if (!(IsAdministrator))
 #
 # Upgrade
 #
-$NodePath = npm config -g get prefix
 if ((Test-Path $NodePath) -ne $True) {
-  $NodePath = $env:ProgramFiles + "\nodejs"
-  if ((Test-Path $NodePath) -ne $True) {
     $NodePath = {env:ProgramFiles(x86)} + "\nodejs"
-  }
 }
 
 $NpmPath = $NodePath + "\node_modules\npm"
@@ -83,7 +82,7 @@ if (Test-Path $NpmPath)
     # Upgrade npm
     cd $NodePath
     "Upgrading npm in " + $NodePath
-    npm install npm@$version
+    .\npm install npm@$version
 
     # Copy .npmrc back
     if ($Npmrc)


### PR DESCRIPTION
I added to the `bin/npm-windows-upgrade` script code to call `npm config --global get prefix` which will return the location that npm is installed in the path.  If that doesn't work it should default to what its using now within the powershell script.

Also fixed some typos, in some places it had "npm-upgrade-windows" within the messages so changed that to "npm-windows-upgrade".

I was getting an error in the script because powershell was unable to run `npm install npm@$version`.  I modified this to `.\npm install npm@$version` and that worked.  See error message I was getting below -

![image](https://cloud.githubusercontent.com/assets/424694/8447940/1ed35128-1f75-11e5-81b0-1f7bf415d152.png)

Updated the code style back to pass grunt test with no errors (although I prefer not using the comma separated args per https://github.com/felixge/node-style-guide when writing server nodejs code).

After these modifications it's working for me with a portable install at ~/local/bin.  I uploaded this to npm as npm-windows-upgrade-portable so that can be used if you do not want to take the pull request.