### PR TITLE
fix: use confirmedPath for powershell.runUpgrade

### DIFF
--- a/lib/upgrade.js
+++ b/lib/upgrade.js
@@ -152,7 +152,7 @@ function upgrade(version, npmPath) {
                 }
 
                 npmpathfinder(npmPath).then(function (confirmedPath) {
-                    powershell.runUpgrade(version, npmPath).then(function callee$2$0(output) {
+                    powershell.runUpgrade(version, confirmedPath).then(function callee$2$0(output) {
                         var _info, installedVersion, _info2;
 
                         return regeneratorRuntime.async(function callee$2$0$(context$3$0) {

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -89,7 +89,7 @@ async function upgrade(version, npmPath) {
     }
 
     npmpathfinder(npmPath).then((confirmedPath) => {
-        powershell.runUpgrade(version, npmPath).then(async function (output) {
+        powershell.runUpgrade(version, confirmedPath).then(async function (output) {
             if (!noPrompt) spinner.stop(false);
             console.log('\n');
 


### PR DESCRIPTION
npmPath could be `undefined` if cli-argument `--npm-path` was not set. So we use the path returned from npmpathfinder for `powershell.runUpgrade`.

fixes #39