### PR TITLE
Fix install by updating bin field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "private": false,
   "preferGlobal": "true",
   "bin": {
-    "npm-windows-upgrade": "./bin/npm-windows-upgrade"
+    "npm-windows-upgrade": "./bin/npm-windows-upgrade.js"
   },
   "repository": "https://github.com/felixrieseberg/npm-windows-upgrade",
   "engines": {


### PR DESCRIPTION
v3.0.0 doesn't install. This should fix that.

For reference, the error you get is:
```
npm ERR! Windows_NT 10.0.10586
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js" "install" "npm-windows-upgrade" "-g"
npm ERR! node v6.2.2
npm ERR! npm  v3.10.3
npm ERR! path C:\Users\User\AppData\Roaming\npm\node_modules\npm-windows-upgrade\bin\npm-windows-upgrade
npm ERR! code ENOENT
npm ERR! errno -4058
npm ERR! syscall chmod

npm ERR! enoent ENOENT: no such file or directory, chmod 'C:\Users\User\AppData\Roaming\npm\node_modules\npm-windows-upgrade\bin\npm-windows-upgrade'
npm ERR! enoent ENOENT: no such file or directory, chmod 'C:\Users\User\AppData\Roaming\npm\node_modules\npm-windows-upgrade\bin\npm-windows-upgrade'
npm ERR! enoent This is most likely not a problem with npm itself
npm ERR! enoent and is related to npm not being able to find a file.
npm ERR! enoent
```
It's trying to link `npm-windows-upgrade` (via the `bin` field in `package.json`), but it looks like that file was renamed to include the `.js` extension in the 3.0.0 rewrite. Updating the `bin` field should do the trick.