### PR TITLE
Allow an execution policy of "Bypass"

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -66,7 +66,7 @@ function checkExecutionPolicy () {
     })
 
     child.on('exit', () => {
-      const linesHit = output.filter((line) => line.includes('Unrestricted') || line.includes('RemoteSigned'))
+      const linesHit = output.filter((line) => line.includes('Unrestricted') || line.includes('RemoteSigned') || line.includes('Bypass'))
       const unrestricted = (linesHit.length > 0)
 
       if (!unrestricted) {


### PR DESCRIPTION
[Boxstarter](http://www.boxstarter.org/) sets the execution policy to `Bypass` but `utils.checkExecutionPolicy()` [only accepted `RemoteSigned` and `Unrestricted`](https://github.com/felixrieseberg/npm-windows-upgrade/blob/a6b535cdf20dbefdefc1f80d87e4ef4047e21b7f/src/utils.js#L69), which lead `npm-windows-upgrade` to refuse to run when triggered by Boxstarter.

Seeing as [`Bypass` is less restrictive than `Unrestricted`](https://technet.microsoft.com/library/hh847748.aspx), it would be great if it were supported.

In the meantime, we are using `--no-execution-policy-check` and it would be great to not need that.

What do you think?

Thanks!
\- Oli