### PR TITLE
Make non-admin error message less specific

### DIFF
--- a/powershell/upgrade-npm.ps1
+++ b/powershell/upgrade-npm.ps1
@@ -104,10 +104,15 @@ function UpdateNpm($PassedNodePath)
 # ---------------------------------------------------------------------------------------------------------
 if (!(IsAdministrator))
 {
-    "NOTADMIN"
-    "Please restart this script from an administrative PowerShell!"
-    "NPM cannot be upgraded without administrative rights. To run PowerShell as Administrator,"
-    "right-click PowerShell and select 'Run as Administrator'"
+    $parentpid=(gwmi win32_process -Filter "processid='$pid'").parentprocessid
+    if((Get-Process -id $parentpid).Name -eq "cmd") {
+        $env = "command prompt"
+    } else {
+        $env = "PowerShell"
+    }
+
+    "Please restart this script from an administrative $env"
+    "NPM cannot be upgraded without administrative rights."
     return
 }
 


### PR DESCRIPTION
The same warning is shown whether the script has been run from PowerShell or cmd.  The script works fine in an administrative command prompt, so no need to send users off to PowerShell.  Additionally, starting an administrative version of either environment can be performed several ways, many of which involve no clicking at all, and most users should be familiar enough with running programs as an Administrator.